### PR TITLE
Update server defaults and dynamic iOS config

### DIFF
--- a/ios-app/config.ts
+++ b/ios-app/config.ts
@@ -6,12 +6,15 @@
 const IS_DEVELOPMENT = __DEV__;
 
 // --- API Configuration ---
+// Allow overriding the API URL via an environment variable exposed by Expo.
+const ENV_API_URL = process.env.EXPO_PUBLIC_API_BASE_URL;
+
 // Development API (your local machine running the backend)
 // IMPORTANT: If running the app on an emulator, simulator, or physical device,
 // replace '127.0.0.1' with your computer's actual IP address on your local network.
 // '127.0.0.1' works if the app is running in a web browser on the SAME machine as the backend.
 const DEV_API_CONFIG = {
-  baseURL: 'http://127.0.0.1:8001/v1', // Using port 8001 for the backend service
+  baseURL: ENV_API_URL || 'http://127.0.0.1:8001/v1', // Using port 8001 for the backend service
   timeout: 15000, // API request timeout in milliseconds (e.g., 15 seconds)
 };
 

--- a/run_ios.py
+++ b/run_ios.py
@@ -3,6 +3,8 @@ import os
 import sys
 from pathlib import Path
 
+from run_server import DEFAULT_HOST, DEFAULT_PORT
+
 def main():
     # Get the project root directory (where this file is located)
     project_root = Path(__file__).parent.absolute()
@@ -14,12 +16,20 @@ def main():
     
     # Change to the ios-app directory
     os.chdir(ios_app_dir)
-    
+
+    # Determine backend URL from run_server configuration
+    host = os.getenv("SERVER_HOST", DEFAULT_HOST)
+    port = os.getenv("SERVER_PORT", str(DEFAULT_PORT))
+    backend_url = f"http://{host}:{port}/v1"
+
+    # Pass the backend URL to the Expo app via environment variable
+    os.environ["EXPO_PUBLIC_API_BASE_URL"] = backend_url
+
     print("Starting iOS app...")
     print("Press Ctrl+C to stop the app")
     
     try:
-        # Run expo start with clear cache
+        # Run expo start with clear cache and environment variables
         subprocess.run(["npx", "expo", "start", "-c"], check=True)
     except KeyboardInterrupt:
         print("\nApp stopped by user")
@@ -31,4 +41,4 @@ def main():
         sys.exit(1)
 
 if __name__ == "__main__":
-    main() 
+    main()

--- a/run_server.py
+++ b/run_server.py
@@ -3,6 +3,10 @@ import os
 import sys
 from pathlib import Path
 
+# Default host and port for the development server
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 8001
+
 def main():
     # Get the project root directory (where this file is located)
     project_root = Path(__file__).parent.absolute()
@@ -17,9 +21,11 @@ def main():
         print("Warning: Not running in a virtual environment. It's recommended to use one.")
     
     # Configuration
-    host = "0.0.0.0"  # Allow external connections
-    port = 8001       # Use port 8001
-    reload = True     # Enable auto-reload for development
+    # Allow overriding the host and port via environment variables, but
+    # default to the values defined above for local development.
+    host = os.getenv("SERVER_HOST", DEFAULT_HOST)
+    port = int(os.getenv("SERVER_PORT", DEFAULT_PORT))
+    reload = True  # Enable auto-reload for development
     
     print(f"Starting server on {host}:{port}")
     print("Press Ctrl+C to stop the server")
@@ -39,4 +45,4 @@ def main():
         sys.exit(1)
 
 if __name__ == "__main__":
-    main() 
+    main()


### PR DESCRIPTION
## Summary
- default FastAPI host/port constants in `run_server.py`
- support overriding host/port via environment variables
- expose backend URL to Expo from `run_ios.py`
- allow Expo config override using `EXPO_PUBLIC_API_BASE_URL`

## Testing
- `python -m py_compile run_server.py run_ios.py`