### PR TITLE
Add drag-and-drop testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,13 @@ OPENAI_API_KEY=your_openai_api_key
 
 #### d. Run the FastAPI app:
 ```bash
-python run_server.py
+# Bind to all interfaces so mobile devices can reach the server
+SERVER_HOST=0.0.0.0 python run_server.py
 ```
 
-The backend will be available at `http://127.0.0.1:8001`.
+The backend will be available on your machine's IP address (e.g., `http://192.168.1.X:8001`).
+
+`run_ios.py` will automatically detect this IP and configure the Expo app accordingly.
 
 ### 2. iOS App Setup
 
@@ -91,6 +94,20 @@ python run_ios.py
 ```
 
 The app will start and provide a QR code that you can scan with the Expo Go app on your iOS device.
+
+### Testing image upload in the iOS simulator
+
+When running the app in the iOS simulator you can quickly add photos without
+using a real device:
+
+1. Drag any image file from your Mac onto the simulator window. It will be
+   imported into the Photos app inside the simulator.
+2. In the PrepSense app tap **Upload Image** and choose the photo you just added.
+3. Tap **Confirm** on the next screen to send the image to the backend (and then
+   on to OpenAI).
+
+This mirrors the flow on a physical device while keeping development entirely on
+your desktop.
 
 ## Collaboration Guidelines
 

--- a/ios-app/README.md
+++ b/ios-app/README.md
@@ -97,14 +97,24 @@ cd ios-app
 npm install
 cd ..
 
-# 3. Start the FastAPI backend (http://127.0.0.1:8001)
-python run_server.py
+# 3. Start the FastAPI backend on your machine's IP
+SERVER_HOST=0.0.0.0 python run_server.py
 
 # 4. Start the Expo app (shows a QR code for Expo Go)
-python run_ios.py
+python run_ios.py  # automatically sets EXPO_PUBLIC_API_BASE_URL
 ```
 
 Scan the QR code printed in the terminal with **Expo Go** on your iOS device to load the app.
+
+### Drag‑and‑drop testing on the iOS simulator
+
+You can add images to the simulator without a physical device:
+
+1. Drag any image file from your Mac onto the simulator window. It will be stored in the Photos app inside the simulator.
+2. In PrepSense tap **Upload Image** and pick the photo you just added.
+3. Press **Confirm** to send it through the backend to OpenAI.
+
+This mirrors the experience on real hardware while staying entirely on your desktop.
 
 ---
 

--- a/ios-app/app/confirm.tsx
+++ b/ios-app/app/confirm.tsx
@@ -1,4 +1,6 @@
 import * as ImagePicker from 'expo-image-picker';
+// Tip: on the iOS simulator you can drag images from your Mac straight onto the
+// simulator window. They appear in the Photos app for easy selection.
 import * as FileSystem from 'expo-file-system';
 import { Buffer } from 'buffer';
 import {

--- a/ios-app/config.ts
+++ b/ios-app/config.ts
@@ -10,8 +10,9 @@ const IS_DEVELOPMENT = __DEV__;
 const ENV_API_URL = process.env.EXPO_PUBLIC_API_BASE_URL;
 
 // Development API (your local machine running the backend)
-// IMPORTANT: If running the app on an emulator, simulator, or physical device,
-// replace '127.0.0.1' with your computer's actual IP address on your local network.
+// `run_ios.py` attempts to detect your computer's IP and sets
+// EXPO_PUBLIC_API_BASE_URL automatically. If that fails,
+// replace '127.0.0.1' with your actual IP address.
 // '127.0.0.1' works if the app is running in a web browser on the SAME machine as the backend.
 const DEV_API_CONFIG = {
   baseURL: ENV_API_URL || 'http://127.0.0.1:8001/v1', // Using port 8001 for the backend service


### PR DESCRIPTION
## Summary
- document how to drag images onto the iOS simulator in both READMEs
- note the drag-and-drop tip directly in `confirm.tsx`

## Testing
- `pytest -q` *(fails: command not found)*