### PR TITLE
fix: restore decimal input functionality

### DIFF
--- a/ios-app/app/add-item.tsx
+++ b/ios-app/app/add-item.tsx
@@ -45,6 +45,7 @@ type Item = {
   expected_expiration: string;
   count: number;
   category: string;
+  quantity_amount_text?: string; // Track the text value separately
 };
 
 export default function AddItem() {
@@ -53,6 +54,7 @@ export default function AddItem() {
   const [form, setForm] = useState<Item>({
     item_name: '',
     quantity_amount: 0,
+    quantity_amount_text: '',
     quantity_unit: 'pcs',
     expected_expiration: new Date().toISOString().split('T')[0],
     count: 1,
@@ -178,15 +180,20 @@ export default function AddItem() {
                 color: '#297A56' 
               }
             ]}
-            value={form.quantity_amount > 0 ? String(form.quantity_amount) : ''}
-            keyboardType="decimal-pad"
+            value={form.quantity_amount_text}
+            keyboardType={Platform.OS === 'ios' ? 'decimal-pad' : 'numeric'}
             onChangeText={(t) => {
               // Allow decimals and validate input
               const cleaned = t.replace(/[^0-9.]/g, '');
               const parts = cleaned.split('.');
               // Allow only one decimal point
               const formatted = parts.length > 2 ? parts[0] + '.' + parts.slice(1).join('') : cleaned;
-              setForm((f: Item) => ({ ...f, quantity_amount: Number(formatted) || 0 }));
+              
+              setForm((f: Item) => ({ 
+                ...f, 
+                quantity_amount_text: formatted,
+                quantity_amount: Number(formatted) || 0 
+              }));
             }}
             onFocus={() => setFocusedInput('amount')}
             placeholder="0"

--- a/ios-app/app/edit-item.tsx
+++ b/ios-app/app/edit-item.tsx
@@ -50,6 +50,7 @@ type Item = {
   expected_expiration: string;
   count?: number;
   category?: string;
+  quantity_amount_text?: string;
 };
 
 export default function EditItem() {
@@ -76,6 +77,7 @@ export default function EditItem() {
         ...item,
         item_name: item.item_name || '',
         quantity_amount: item.quantity_amount || 0,
+        quantity_amount_text: String(item.quantity_amount || 0),
         quantity_unit: item.quantity_unit || 'pcs',
         expected_expiration: item.expected_expiration || new Date().toISOString().split('T')[0],
         count: item.count || 1,
@@ -86,6 +88,7 @@ export default function EditItem() {
       return {
         item_name: '',
         quantity_amount: 0,
+        quantity_amount_text: '0',
         quantity_unit: 'pcs',
         expected_expiration: new Date().toISOString().split('T')[0],
         count: 1,
@@ -199,15 +202,19 @@ export default function EditItem() {
                 color: '#297A56' 
               }
             ]}
-            value={String(form.quantity_amount)}
-            keyboardType="decimal-pad"
+            value={form.quantity_amount_text}
+            keyboardType={Platform.OS === 'ios' ? 'decimal-pad' : 'numeric'}
             onChangeText={(t) => {
               // Allow decimals and validate input
               const cleaned = t.replace(/[^0-9.]/g, '');
               const parts = cleaned.split('.');
               // Allow only one decimal point
               const formatted = parts.length > 2 ? parts[0] + '.' + parts.slice(1).join('') : cleaned;
-              setForm((f: Item) => ({ ...f, quantity_amount: Number(formatted) || 0 }));
+              setForm((f: Item) => ({ 
+                ...f, 
+                quantity_amount_text: formatted,
+                quantity_amount: Number(formatted) || 0 
+              }));
             }}
             onFocus={() => setFocusedInput('amount')}
           />


### PR DESCRIPTION
## Summary
Restores the decimal input functionality that was missing from the main branch after the previous PR merge.

## Problem
- Users couldn't type decimal numbers (e.g., 1.5, 0.75) in quantity fields
- Typing "1." would show as "1" in the input field
- The decimal fix from commit 288ac58 was not included in the merged PR

## Solution
- Re-implemented the `quantity_amount_text` field to track text value separately
- Input now properly displays decimal points while typing
- Numeric value is still validated and stored in `quantity_amount`

## Test plan
- [x] Test decimal input in add-item screen (e.g., 1.5 kg)
- [x] Test decimal input in edit-item screen
- [x] Verify decimal point shows while typing "1."
- [x] Confirm decimal pad keyboard appears on iOS