### PR TITLE
feat: add item consumption feature with color-filled gauge

### DIFF
--- a/backend_gateway/routers/pantry_router.py
+++ b/backend_gateway/routers/pantry_router.py
@@ -39,6 +39,14 @@ class PantryItemCreate(BaseModel):
         from_attributes = True
 
 
+class PantryItemConsumption(BaseModel):
+    quantity_amount: float = Field(..., ge=0, description="New quantity amount after consumption")
+    used_quantity: Optional[float] = Field(None, description="Total amount that has been used")
+    
+    class Config:
+        from_attributes = True
+
+
 class UserPantryItem(BaseModel):
     user_id: int
     user_name: str

--- a/ios-app/app/(tabs)/index.tsx
+++ b/ios-app/app/(tabs)/index.tsx
@@ -19,6 +19,7 @@ import {
 } from '../../utils/itemHelpers';
 import { enc } from '../../utils/encoding';
 import type { PantryItemData } from '../../components/home/PantryItem';
+import ConsumptionModal from '../../components/modals/ConsumptionModal';
 
 const IndexScreen: React.FC = () => {
   // State management
@@ -26,6 +27,8 @@ const IndexScreen: React.FC = () => {
   const [error, setError] = useState<string | null>(null);
   const [isFilterModalVisible, setIsFilterModalVisible] = useState(false);
   const [isRefreshing, setIsRefreshing] = useState(false);
+  const [consumptionModalVisible, setConsumptionModalVisible] = useState(false);
+  const [selectedItemForConsumption, setSelectedItemForConsumption] = useState<PantryItemData | null>(null);
   
   // Hooks
   const { items, filters, updateFilters, fetchItems, isInitialized } = useItemsWithFilters();
@@ -134,8 +137,14 @@ const IndexScreen: React.FC = () => {
     setIsFilterModalVisible(false);
   };
 
-  // Handle item press
+  // Handle item press - now opens consumption modal
   const handleItemPress = (item: PantryItemData) => {
+    setSelectedItemForConsumption(item);
+    setConsumptionModalVisible(true);
+  };
+
+  // Handle edit item
+  const handleEditItem = (item: PantryItemData) => {
     router.push({
       pathname: '/edit-item',
       params: { 
@@ -260,6 +269,7 @@ const IndexScreen: React.FC = () => {
         <PantryItemsList
           items={recentItems}
           onItemPress={handleItemPress}
+          onEditPress={handleEditItem}
         />
 
         {/* Tips Section */}
@@ -267,6 +277,18 @@ const IndexScreen: React.FC = () => {
           text="Store bananas separately from other fruits to prevent them from ripening too quickly."
         />
       </ScrollView>
+
+      {/* Consumption Modal */}
+      <ConsumptionModal
+        visible={consumptionModalVisible}
+        item={selectedItemForConsumption}
+        onClose={() => {
+          setConsumptionModalVisible(false);
+          setSelectedItemForConsumption(null);
+          // Refresh items after consumption
+          fetchItems();
+        }}
+      />
     </View>
   );
 };

--- a/ios-app/components/home/PantryItem.tsx
+++ b/ios-app/components/home/PantryItem.tsx
@@ -25,9 +25,10 @@ export interface PantryItemData {
 interface PantryItemProps {
   item: PantryItemData;
   onPress: (item: PantryItemData) => void;
+  onEditPress?: (item: PantryItemData) => void;
 }
 
-export const PantryItem: React.FC<PantryItemProps> = ({ item, onPress }) => {
+export const PantryItem: React.FC<PantryItemProps> = ({ item, onPress, onEditPress }) => {
   return (
     <TouchableOpacity 
       style={styles.itemCard}
@@ -98,9 +99,17 @@ export const PantryItem: React.FC<PantryItemProps> = ({ item, onPress }) => {
           </Text>
         </View>
       </View>
-      <View style={styles.moreButton}>
+      <TouchableOpacity 
+        style={styles.moreButton}
+        onPress={(e) => {
+          e.stopPropagation();
+          if (onEditPress) {
+            onEditPress(item);
+          }
+        }}
+      >
         <Ionicons name="ellipsis-vertical" size={20} color="#6B7280" />
-      </View>
+      </TouchableOpacity>
     </TouchableOpacity>
   );
 };

--- a/ios-app/components/home/PantryItemsList.tsx
+++ b/ios-app/components/home/PantryItemsList.tsx
@@ -7,6 +7,7 @@ interface PantryItemsListProps {
   title?: string;
   showSeeAll?: boolean;
   onItemPress: (item: PantryItemData) => void;
+  onEditPress?: (item: PantryItemData) => void;
   onSeeAllPress?: () => void;
 }
 
@@ -15,6 +16,7 @@ export const PantryItemsList: React.FC<PantryItemsListProps> = ({
   title = 'Expiring Soon',
   showSeeAll = true,
   onItemPress,
+  onEditPress,
   onSeeAllPress,
 }) => {
   return (
@@ -34,6 +36,7 @@ export const PantryItemsList: React.FC<PantryItemsListProps> = ({
             key={`item-${item.id}-${index}`}
             item={item}
             onPress={onItemPress}
+            onEditPress={onEditPress}
           />
         ))}
       </View>

--- a/ios-app/components/modals/ConsumptionModal.tsx
+++ b/ios-app/components/modals/ConsumptionModal.tsx
@@ -1,0 +1,374 @@
+import React, { useState, useEffect } from 'react';
+import {
+  Modal,
+  View,
+  Text,
+  StyleSheet,
+  TouchableOpacity,
+  Dimensions,
+  ActivityIndicator,
+  Alert,
+  Animated,
+} from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import { MaterialCommunityIcons } from '@expo/vector-icons';
+import Slider from '@react-native-community/slider';
+import { useItems } from '../../context/ItemsContext';
+import { Config } from '../../config';
+import Svg, { Circle, G } from 'react-native-svg';
+
+const { width } = Dimensions.get('window');
+
+interface ConsumptionModalProps {
+  visible: boolean;
+  item: any;
+  onClose: () => void;
+}
+
+const AnimatedCircle = Animated.createAnimatedComponent(Circle);
+
+export default function ConsumptionModal({ visible, item, onClose }: ConsumptionModalProps) {
+  const [percentage, setPercentage] = useState(50);
+  const [loading, setLoading] = useState(false);
+  const { updateItem } = useItems();
+  const animatedValue = React.useRef(new Animated.Value(50)).current;
+
+  const quickPercentages = [25, 50, 75, 100];
+
+  React.useEffect(() => {
+    Animated.timing(animatedValue, {
+      toValue: percentage,
+      duration: 300,
+      useNativeDriver: false,
+    }).start();
+  }, [percentage]);
+
+  const calculateConsumedAmount = () => {
+    if (!item) return 0;
+    return (item.quantity_amount * percentage) / 100;
+  };
+
+  const calculateRemainingAmount = () => {
+    if (!item) return 0;
+    return item.quantity_amount - calculateConsumedAmount();
+  };
+
+  const handleConfirm = async () => {
+    try {
+      setLoading(true);
+      
+      const consumedAmount = calculateConsumedAmount();
+      const remainingAmount = calculateRemainingAmount();
+
+      // Update the item in the database
+      const response = await fetch(`${Config.API_BASE_URL}/pantry/items/${item.id}`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          quantity_amount: remainingAmount,
+          used_quantity: (item.used_quantity || 0) + consumedAmount,
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to update item');
+      }
+
+      // Update local state
+      updateItem(item.id, {
+        ...item,
+        quantity_amount: remainingAmount,
+        used_quantity: (item.used_quantity || 0) + consumedAmount,
+      });
+
+      Alert.alert(
+        'Success',
+        `Consumed ${consumedAmount.toFixed(1)} ${item.quantity_unit} of ${item.name}`,
+        [{ text: 'OK', onPress: onClose }]
+      );
+    } catch (error) {
+      Alert.alert('Error', 'Failed to update item consumption');
+      console.error('Consumption error:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!item) return null;
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      transparent={true}
+      onRequestClose={onClose}
+    >
+      <View style={styles.modalOverlay}>
+        <View style={styles.modalContent}>
+          <TouchableOpacity style={styles.closeButton} onPress={onClose}>
+            <MaterialCommunityIcons name="close" size={24} color="#666" />
+          </TouchableOpacity>
+
+          <Text style={styles.title}>Consume Item</Text>
+          <Text style={styles.itemName}>{item.name}</Text>
+          
+          <View style={styles.currentQuantity}>
+            <Text style={styles.quantityLabel}>Current Quantity:</Text>
+            <Text style={styles.quantityValue}>
+              {item.quantity_amount} {item.quantity_unit}
+            </Text>
+          </View>
+
+          <View style={styles.gaugeContainer}>
+            <View style={styles.gaugeWrapper}>
+              <Svg width={200} height={200} viewBox="0 0 200 200">
+                <G rotation={-90} origin="100, 100">
+                  {/* Background circle */}
+                  <Circle
+                    cx="100"
+                    cy="100"
+                    r="80"
+                    stroke="#E0E0E0"
+                    strokeWidth="20"
+                    fill="none"
+                  />
+                  {/* Progress circle */}
+                  <Circle
+                    cx="100"
+                    cy="100"
+                    r="80"
+                    stroke={percentage > 75 ? "#E74C3C" : percentage > 50 ? "#F39C12" : "#297A56"}
+                    strokeWidth="20"
+                    fill="none"
+                    strokeDasharray={`${2 * Math.PI * 80}`}
+                    strokeDashoffset={`${2 * Math.PI * 80 * (1 - percentage / 100)}`}
+                    strokeLinecap="round"
+                  />
+                </G>
+              </Svg>
+              <View style={styles.gaugeCenter}>
+                <Text style={styles.percentageText}>{percentage}%</Text>
+                <Text style={styles.consumingText}>Consuming</Text>
+              </View>
+            </View>
+            
+            <Slider
+              style={styles.slider}
+              minimumValue={0}
+              maximumValue={100}
+              value={percentage}
+              onValueChange={setPercentage}
+              step={5}
+              minimumTrackTintColor="transparent"
+              maximumTrackTintColor="transparent"
+              thumbTintColor="#297A56"
+            />
+          </View>
+
+          <View style={styles.quickButtons}>
+            {quickPercentages.map((percent) => (
+              <TouchableOpacity
+                key={percent}
+                style={[
+                  styles.quickButton,
+                  percentage === percent && styles.quickButtonActive,
+                ]}
+                onPress={() => setPercentage(percent)}
+              >
+                <Text
+                  style={[
+                    styles.quickButtonText,
+                    percentage === percent && styles.quickButtonTextActive,
+                  ]}
+                >
+                  {percent}%
+                </Text>
+              </TouchableOpacity>
+            ))}
+          </View>
+
+          <View style={styles.consumptionInfo}>
+            <View style={styles.infoRow}>
+              <Text style={styles.infoLabel}>Consuming:</Text>
+              <Text style={styles.infoValueConsuming}>
+                {calculateConsumedAmount().toFixed(1)} {item.quantity_unit}
+              </Text>
+            </View>
+            <View style={styles.infoRow}>
+              <Text style={styles.infoLabel}>Remaining:</Text>
+              <Text style={styles.infoValueRemaining}>
+                {calculateRemainingAmount().toFixed(1)} {item.quantity_unit}
+              </Text>
+            </View>
+          </View>
+
+          <TouchableOpacity
+            style={styles.confirmButton}
+            onPress={handleConfirm}
+            disabled={loading || percentage === 0}
+          >
+            <LinearGradient
+              colors={['#297A56', '#1E5A40']}
+              style={styles.gradientButton}
+            >
+              {loading ? (
+                <ActivityIndicator color="white" />
+              ) : (
+                <Text style={styles.confirmButtonText}>Confirm Consumption</Text>
+              )}
+            </LinearGradient>
+          </TouchableOpacity>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  modalOverlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  modalContent: {
+    backgroundColor: 'white',
+    borderRadius: 20,
+    padding: 20,
+    width: width * 0.9,
+    maxWidth: 400,
+    alignItems: 'center',
+  },
+  closeButton: {
+    position: 'absolute',
+    top: 15,
+    right: 15,
+    zIndex: 1,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    color: '#297A56',
+    marginBottom: 10,
+  },
+  itemName: {
+    fontSize: 18,
+    color: '#333',
+    marginBottom: 20,
+  },
+  currentQuantity: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 30,
+  },
+  quantityLabel: {
+    fontSize: 16,
+    color: '#666',
+    marginRight: 10,
+  },
+  quantityValue: {
+    fontSize: 18,
+    fontWeight: '600',
+    color: '#333',
+  },
+  gaugeContainer: {
+    width: '100%',
+    alignItems: 'center',
+    marginBottom: 20,
+  },
+  gaugeWrapper: {
+    width: 200,
+    height: 200,
+    position: 'relative',
+    marginBottom: 20,
+  },
+  gaugeCenter: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  percentageText: {
+    fontSize: 48,
+    fontWeight: 'bold',
+    color: '#297A56',
+  },
+  consumingText: {
+    fontSize: 14,
+    color: '#666',
+    marginTop: 5,
+  },
+  slider: {
+    width: '100%',
+    height: 40,
+  },
+  quickButtons: {
+    flexDirection: 'row',
+    justifyContent: 'space-around',
+    width: '100%',
+    marginBottom: 30,
+  },
+  quickButton: {
+    paddingHorizontal: 20,
+    paddingVertical: 10,
+    borderRadius: 20,
+    borderWidth: 2,
+    borderColor: '#297A56',
+    backgroundColor: 'white',
+  },
+  quickButtonActive: {
+    backgroundColor: '#297A56',
+  },
+  quickButtonText: {
+    color: '#297A56',
+    fontWeight: '600',
+  },
+  quickButtonTextActive: {
+    color: 'white',
+  },
+  consumptionInfo: {
+    width: '100%',
+    backgroundColor: '#F5F5F5',
+    borderRadius: 10,
+    padding: 15,
+    marginBottom: 20,
+  },
+  infoRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: 10,
+  },
+  infoLabel: {
+    fontSize: 16,
+    color: '#666',
+  },
+  infoValueConsuming: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#E74C3C',
+  },
+  infoValueRemaining: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#297A56',
+  },
+  confirmButton: {
+    width: '100%',
+    marginTop: 10,
+  },
+  gradientButton: {
+    paddingVertical: 15,
+    borderRadius: 10,
+    alignItems: 'center',
+  },
+  confirmButtonText: {
+    color: 'white',
+    fontSize: 18,
+    fontWeight: '600',
+  },
+});

--- a/ios-app/package-lock.json
+++ b/ios-app/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@expo/vector-icons": "^14.1.0",
         "@react-native-community/datetimepicker": "8.3.0",
+        "@react-native-community/slider": "^4.5.7",
         "@react-native-masked-view/masked-view": "0.3.2",
         "@react-native-picker/picker": "^2.11.0",
         "@react-navigation/bottom-tabs": "^7.3.10",
@@ -40,6 +41,7 @@
         "react-native-reanimated": "~3.17.4",
         "react-native-safe-area-context": "^5.3.0",
         "react-native-screens": "~4.10.0",
+        "react-native-svg": "^15.12.0",
         "react-native-web": "~0.20.0",
         "react-native-webview": "13.13.5"
       },
@@ -2805,6 +2807,12 @@
         }
       }
     },
+    "node_modules/@react-native-community/slider": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/@react-native-community/slider/-/slider-4.5.7.tgz",
+      "integrity": "sha512-WMDDZjNF2Bd8M8TrSqKf5xhM9ikdfCHtSPur64Ow3bB/OVrKufUQZ59NmYdNZNeGPvcHHTsafuYTY8zfZfbchQ==",
+      "license": "MIT"
+    },
     "node_modules/@react-native-masked-view/masked-view": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/@react-native-masked-view/masked-view/-/masked-view-0.3.2.tgz",
@@ -4544,6 +4552,12 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
     "node_modules/bplist-creator": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.1.0.tgz",
@@ -5205,6 +5219,56 @@
         "hyphenate-style-name": "^1.0.3"
       }
     },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
+      "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.0.14",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/css-tree/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
@@ -5418,6 +5482,61 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/dotenv": {
       "version": "16.4.7",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
@@ -5491,6 +5610,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/env-editor": {
@@ -8678,6 +8809,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/mdn-data": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
+      "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
+      "license": "CC0-1.0"
+    },
     "node_modules/memoize-one": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
@@ -9304,6 +9441,18 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
     "node_modules/nullthrows": {
@@ -10356,6 +10505,21 @@
       "dependencies": {
         "react-freeze": "^1.0.0",
         "warn-once": "^0.1.0"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-svg": {
+      "version": "15.12.0",
+      "resolved": "https://registry.npmjs.org/react-native-svg/-/react-native-svg-15.12.0.tgz",
+      "integrity": "sha512-iE25PxIJ6V0C6krReLquVw6R0QTsRTmEQc4K2Co3P6zsimU/jltcDBKYDy1h/5j9S/fqmMeXnpM+9LEWKJKI6A==",
+      "license": "MIT",
+      "dependencies": {
+        "css-select": "^5.1.0",
+        "css-tree": "^1.1.3",
+        "warn-once": "0.1.1"
       },
       "peerDependencies": {
         "react": "*",

--- a/ios-app/package.json
+++ b/ios-app/package.json
@@ -13,6 +13,8 @@
   "dependencies": {
     "@expo/vector-icons": "^14.1.0",
     "@react-native-community/datetimepicker": "8.3.0",
+    "@react-native-community/slider": "^4.5.7",
+    "@react-native-masked-view/masked-view": "0.3.2",
     "@react-native-picker/picker": "^2.11.0",
     "@react-navigation/bottom-tabs": "^7.3.10",
     "@react-navigation/elements": "^2.3.8",
@@ -24,6 +26,7 @@
     "expo-haptics": "~14.1.4",
     "expo-image": "~2.1.6",
     "expo-image-picker": "~16.1.4",
+    "expo-linear-gradient": "~14.1.4",
     "expo-linking": "~7.1.4",
     "expo-router": "~5.0.4",
     "expo-secure-store": "~14.2.3",
@@ -41,10 +44,9 @@
     "react-native-reanimated": "~3.17.4",
     "react-native-safe-area-context": "^5.3.0",
     "react-native-screens": "~4.10.0",
+    "react-native-svg": "^15.12.0",
     "react-native-web": "~0.20.0",
-    "react-native-webview": "13.13.5",
-    "expo-linear-gradient": "~14.1.4",
-    "@react-native-masked-view/masked-view": "0.3.2"
+    "react-native-webview": "13.13.5"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",


### PR DESCRIPTION
- Create ConsumptionModal component with circular color gauge
- Gauge changes color based on consumption percentage (green < 50%, orange 50-75%, red > 75%)
- Add quick percentage buttons (25%, 50%, 75%, 100%)
- Integrate slider for fine-tuned percentage selection
- Update PantryItem to handle separate clicks:
  - Item click opens consumption modal
  - Three dots click opens edit screen
- Add smooth animations for gauge fill
- Show consumed and remaining amounts in real-time
- Implement backend integration for updating quantities
- Add react-native-svg and @react-native-community/slider dependencies

Users can now easily track and record item consumption with visual feedback