### PR TITLE
Fix recipe instruction truncation and improve quality filtering

### DIFF
--- a/backend_gateway/routers/spoonacular_router.py
+++ b/backend_gateway/routers/spoonacular_router.py
@@ -76,6 +76,14 @@ async def search_recipes_by_ingredients(
             ignore_pantry=request.ignore_pantry,
             intolerances=request.intolerances
         )
+        
+        # Filter out recipes with insufficient instructions
+        original_count = len(recipes)
+        recipes = spoonacular_service.filter_recipes_by_instructions(recipes, min_steps=2)
+        filtered_count = original_count - len(recipes)
+        if filtered_count > 0:
+            logger.info(f"Filtered out {filtered_count} recipes with insufficient instructions")
+        
         return recipes
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
@@ -105,6 +113,18 @@ async def search_recipes_complex(
             number=request.number,
             offset=request.offset
         )
+        
+        # Filter out recipes with insufficient instructions
+        if 'results' in results:
+            original_count = len(results['results'])
+            results['results'] = spoonacular_service.filter_recipes_by_instructions(
+                results['results'], 
+                min_steps=2
+            )
+            filtered_count = original_count - len(results['results'])
+            if filtered_count > 0:
+                logger.info(f"Filtered out {filtered_count} recipes with insufficient instructions")
+        
         return results
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))

--- a/ios-app/app/recipe-details.tsx
+++ b/ios-app/app/recipe-details.tsx
@@ -271,19 +271,32 @@ export default function RecipeDetailsScreen() {
         if (parsed && parsed.name && parsed.name.trim()) {
           // If we successfully parsed the ingredient
           displayName = parsed.name;
-          if (parsed.quantity && parsed.unit) {
+          if (parsed.quantity && parsed.unit && parsed.unit !== 'piece') {
             displayQuantity = `${parsed.quantity} ${parsed.unit}`;
+          } else if (parsed.quantity && parsed.unit === 'piece') {
+            displayQuantity = `${parsed.quantity}`;
           } else if (parsed.quantity) {
             displayQuantity = `${parsed.quantity}`;
           }
         } else {
-          // If parsing failed, use the original string
-          displayName = cleanedIngredient;
+          // If parsing failed, try a simple split approach
+          // Check for patterns like "ingredient name (quantity)"
+          const parenMatch = cleanedIngredient.match(/^(.+?)\s*\(([^)]+)\)\s*$/);
+          if (parenMatch) {
+            displayName = parenMatch[1].trim();
+            displayQuantity = parenMatch[2].trim();
+          } else {
+            // Use the original string as the name
+            displayName = cleanedIngredient;
+          }
         }
+        
+        // Final cleanup - ensure name doesn't have leading/trailing special chars
+        displayName = displayName.replace(/^[-,\s]+|[-,\s]+$/g, '').trim();
         
         return {
           id: `${Date.now()}_${index}_${Math.random().toString(36).substr(2, 9)}`,
-          name: displayName,
+          name: displayName || cleanedIngredient, // Fallback to original if name is empty
           quantity: displayQuantity || undefined,
           checked: false,
           addedAt: new Date(),

--- a/ios-app/app/recipe-spoonacular-detail.tsx
+++ b/ios-app/app/recipe-spoonacular-detail.tsx
@@ -20,7 +20,7 @@ import { useAuth } from '../context/AuthContext';
 import { completeRecipe, RecipeIngredient } from '../services/api';
 import { parseIngredientsList } from '../utils/ingredientParser';
 import { calculateIngredientAvailability, validateIngredientCounts } from '../utils/ingredientMatcher';
-import { validateInstructions, getDefaultInstructions, isInappropriateContent } from '../utils/contentValidation';
+import { validateInstructions, isInappropriateContent } from '../utils/contentValidation';
 
 const { width } = Dimensions.get('window');
 
@@ -369,7 +369,7 @@ export default function RecipeSpoonacularDetail() {
       ingredients: recipe.extendedIngredients.map(ing => ing.original),
       instructions: recipe.analyzedInstructions[0]?.steps
         .map(step => cleanInstructionText(step.step))
-        .filter(text => text.length > 0) || getDefaultInstructions(recipe.title),
+        .filter(text => text.length > 0) || [],
       nutrition: {
         calories: recipe.nutrition?.nutrients.find(n => n.name === 'Calories')?.amount || 0,
         protein: recipe.nutrition?.nutrients.find(n => n.name === 'Protein')?.amount || 0,
@@ -766,14 +766,7 @@ export default function RecipeSpoonacularDetail() {
                 })
                 .filter(Boolean)
             ) : (
-              getDefaultInstructions(recipe.title).map((instruction, index) => (
-                <View key={`default-step-${index}`} style={styles.instructionStep}>
-                  <View style={styles.stepNumber}>
-                    <Text style={styles.stepNumberText}>{index + 1}</Text>
-                  </View>
-                  <Text style={styles.stepText}>{instruction}</Text>
-                </View>
-              ))
+              <Text style={styles.noInstructions}>No instructions available for this recipe.</Text>
             )}
           </View>
         )}

--- a/ios-app/components/recipes/RecipeDetailCardV2.tsx
+++ b/ios-app/components/recipes/RecipeDetailCardV2.tsx
@@ -45,7 +45,6 @@ export default function RecipeDetailCardV2({
   const router = useRouter();
   const [isBookmarked, setIsBookmarked] = useState(recipe.is_favorite || false);
   const [showAllIngredients, setShowAllIngredients] = useState(false);
-  const [showAllSteps, setShowAllSteps] = useState(false);
   const [showShoppingList, setShowShoppingList] = useState(true);
   const [isLoading, setIsLoading] = useState(false);
   const [hasCookedRecipe, setHasCookedRecipe] = useState(false);
@@ -67,18 +66,16 @@ export default function RecipeDetailCardV2({
   const availableIngredients = processedIngredients.filter(ing => ing.isAvailable);
   const missingIngredients = processedIngredients.filter(ing => !ing.isAvailable);
   
-  // For progressive disclosure
+  // For progressive disclosure - only for ingredients
   const INITIAL_INGREDIENTS_SHOWN = 5;
-  const INITIAL_STEPS_SHOWN = 3;
   
   const displayedIngredients = showAllIngredients 
     ? processedIngredients 
     : processedIngredients.slice(0, INITIAL_INGREDIENTS_SHOWN);
     
   const instructions = recipe.analyzedInstructions?.[0]?.steps || [];
-  const displayedSteps = showAllSteps 
-    ? instructions 
-    : instructions.slice(0, INITIAL_STEPS_SHOWN);
+  // Always show all steps - no truncation
+  const displayedSteps = instructions;
 
   const handleBookmark = async () => {
     Animated.sequence([
@@ -369,23 +366,6 @@ export default function RecipeDetailCardV2({
           ))}
         </View>
 
-        {instructions.length > INITIAL_STEPS_SHOWN && (
-          <TouchableOpacity
-            style={styles.showMoreButton}
-            onPress={() => setShowAllSteps(!showAllSteps)}
-          >
-            <Text style={styles.showMoreText}>
-              {showAllSteps 
-                ? 'Show less' 
-                : `Show all ${instructions.length} steps`}
-            </Text>
-            <Ionicons 
-              name={showAllSteps ? "chevron-up" : "chevron-down"} 
-              size={16} 
-              color="#007AFF" 
-            />
-          </TouchableOpacity>
-        )}
       </View>
 
       {/* Bottom Actions (only shown after cooking) */}

--- a/ios-app/utils/ingredientParser.ts
+++ b/ios-app/utils/ingredientParser.ts
@@ -56,12 +56,47 @@ export function parseIngredient(ingredientString: string): ParsedIngredient {
   // "3 tomatoes"
   // "Salt to taste"
   // "Olive oil"
+  // "flour - 2 cups"
+  // "eggs (large) - 3"
+  
+  // Handle format "ingredient - quantity unit"
+  if (original.includes(' - ')) {
+    const parts = original.split(' - ');
+    if (parts.length === 2) {
+      const name = parts[0].trim();
+      const quantityPart = parts[1].trim();
+      
+      // Try to parse the quantity part
+      const quantityMatch = quantityPart.match(/^(\d+(?:\.\d+)?|\d+\/\d+)\s*(.*)$/);
+      if (quantityMatch) {
+        let quantity: number;
+        const quantityStr = quantityMatch[1];
+        if (quantityStr.includes('/')) {
+          const [numerator, denominator] = quantityStr.split('/').map(Number);
+          quantity = numerator / denominator;
+        } else {
+          quantity = parseFloat(quantityStr);
+        }
+        
+        const unitStr = quantityMatch[2]?.toLowerCase() || '';
+        const unit = unitMappings[unitStr] || unitStr || 'piece';
+        
+        return {
+          name,
+          quantity,
+          unit,
+          originalString: original,
+        };
+      }
+    }
+  }
   
   // Remove common phrases but keep the ingredient name intact
   let cleaned = original
     .replace(/\s+of\s+/gi, ' ')
     .replace(/\s+to taste/gi, '')
     .replace(/,.*$/, '') // Remove everything after comma
+    .replace(/\([^)]*\)/g, '') // Remove parenthetical content
     .trim();
   
   // Try to extract quantity and unit


### PR DESCRIPTION
## Summary
- Remove instruction truncation that was limiting recipes to show only 3 steps initially
- Eliminate default instruction fallbacks - only show actual Spoonacular data
- Add backend validation to ensure recipes have sufficient instructions

## Changes Made

### Frontend Changes
1. **RecipeDetailCardV2.tsx**
   - Removed `INITIAL_STEPS_SHOWN` limit that was truncating to 3 steps
   - Always display all recipe steps without progressive disclosure
   - Removed "Show all steps" button and related state

2. **recipe-spoonacular-detail.tsx**
   - Removed default instruction fallbacks
   - Show "No instructions available" message for recipes without steps
   - Only display actual data from Spoonacular API

### Backend Changes
3. **SpoonacularService**
   - Added `validate_recipe_instructions()` method to check step count
   - Added `filter_recipes_by_instructions()` to filter recipe lists
   - Minimum requirement: 2 steps (configurable)
   - Logs warnings for recipes with insufficient instructions

4. **Spoonacular Router**
   - Added filtering to both search endpoints
   - Recipes with fewer than 2 steps are filtered out
   - Logs count of filtered recipes for monitoring

## Test Plan
- [x] Verify all recipe steps are displayed without truncation
- [x] Confirm recipes with <2 steps are filtered out
- [x] Check that no default instructions are shown
- [x] Test Baked Custard recipe shows all 4 steps

Fixes issue where users complained about recipe instructions being cut off.

Authored-By: danielk7 <danielk7@users.noreply.github.com>