### PR TITLE
Fix shopping list fraction display bug

### DIFF
--- a/ios-app/app/recipe-details.tsx
+++ b/ios-app/app/recipe-details.tsx
@@ -18,7 +18,7 @@ import { useAuth } from '../context/AuthContext';
 import { parseIngredientsList } from '../utils/ingredientParser';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { RecipeCompletionModal } from '../components/modals/RecipeCompletionModal';
-import { formatQuantity } from '../utils/numberFormatting';
+import { formatQuantity, formatIngredientQuantity } from '../utils/numberFormatting';
 import { validateInstructions, getDefaultInstructions } from '../utils/contentValidation';
 
 export default function RecipeDetailsScreen() {
@@ -272,11 +272,15 @@ export default function RecipeDetailsScreen() {
           // If we successfully parsed the ingredient
           displayName = parsed.name;
           if (parsed.quantity && parsed.unit && parsed.unit !== 'piece') {
-            displayQuantity = `${parsed.quantity} ${parsed.unit}`;
+            // Use proper fraction formatting
+            const formattedQuantity = formatIngredientQuantity(parsed.quantity, parsed.unit);
+            displayQuantity = formattedQuantity ? `${formattedQuantity} ${parsed.unit}` : `${parsed.quantity} ${parsed.unit}`;
           } else if (parsed.quantity && parsed.unit === 'piece') {
-            displayQuantity = `${parsed.quantity}`;
+            // Use proper fraction formatting for piece quantities
+            displayQuantity = formatIngredientQuantity(parsed.quantity, '') || `${parsed.quantity}`;
           } else if (parsed.quantity) {
-            displayQuantity = `${parsed.quantity}`;
+            // Use proper fraction formatting for quantity only
+            displayQuantity = formatIngredientQuantity(parsed.quantity, '') || `${parsed.quantity}`;
           }
         } else {
           // If parsing failed, try a simple split approach

--- a/ios-app/app/recipe-spoonacular-detail.tsx
+++ b/ios-app/app/recipe-spoonacular-detail.tsx
@@ -21,6 +21,7 @@ import { completeRecipe, RecipeIngredient } from '../services/api';
 import { parseIngredientsList } from '../utils/ingredientParser';
 import { calculateIngredientAvailability, validateIngredientCounts } from '../utils/ingredientMatcher';
 import { validateInstructions, isInappropriateContent } from '../utils/contentValidation';
+import { formatIngredientQuantity } from '../utils/numberFormatting';
 
 const { width } = Dimensions.get('window');
 
@@ -273,17 +274,22 @@ export default function RecipeSpoonacularDetail() {
           // If we successfully parsed the ingredient
           displayName = parsed.name;
           if (parsed.quantity && parsed.unit) {
-            displayQuantity = `${parsed.quantity} ${parsed.unit}`;
+            // Use proper fraction formatting
+            const formattedQuantity = formatIngredientQuantity(parsed.quantity, parsed.unit);
+            displayQuantity = formattedQuantity ? `${formattedQuantity} ${parsed.unit}` : `${parsed.quantity} ${parsed.unit}`;
           } else if (parsed.quantity) {
-            displayQuantity = `${parsed.quantity}`;
+            // Use proper fraction formatting for quantity only
+            displayQuantity = formatIngredientQuantity(parsed.quantity, '') || `${parsed.quantity}`;
           }
         } else {
-          // If parsing failed, use the ingredient name from Spoonacular
+          // If parsing failed, use the ingredient name from Spoonacular and original amount
           displayName = fallbackName;
-          // Try to extract just the amount and unit from the original string
-          const amountMatch = cleanedOriginal.match(/^([\d.\/\s]+)\s*([a-zA-Z]+)?/);
-          if (amountMatch && amountMatch[1]) {
-            displayQuantity = amountMatch[0].trim();
+          // Use Spoonacular's formatted amount and unit which should already be properly formatted
+          if (ingredient.amount && ingredient.unit) {
+            const formattedQuantity = formatIngredientQuantity(ingredient.amount, ingredient.unit);
+            displayQuantity = formattedQuantity ? `${formattedQuantity} ${ingredient.unit}` : `${ingredient.amount} ${ingredient.unit}`;
+          } else if (ingredient.amount) {
+            displayQuantity = formatIngredientQuantity(ingredient.amount, '') || `${ingredient.amount}`;
           }
         }
         

--- a/ios-app/app/select-ingredients.tsx
+++ b/ios-app/app/select-ingredients.tsx
@@ -12,6 +12,7 @@ import { useLocalSearchParams, useRouter } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { parseIngredientsList } from '../utils/ingredientParser';
+import { formatIngredientQuantity } from '../utils/numberFormatting';
 
 interface SelectableIngredient {
   original: string;
@@ -41,9 +42,12 @@ export default function SelectIngredientsScreen() {
           if (parsed && parsed.name && parsed.name.trim()) {
             displayName = parsed.name;
             if (parsed.quantity && parsed.unit) {
-              displayQuantity = `${parsed.quantity} ${parsed.unit}`;
+              // Use proper fraction formatting
+              const formattedQuantity = formatIngredientQuantity(parsed.quantity, parsed.unit);
+              displayQuantity = formattedQuantity ? `${formattedQuantity} ${parsed.unit}` : `${parsed.quantity} ${parsed.unit}`;
             } else if (parsed.quantity) {
-              displayQuantity = `${parsed.quantity}`;
+              // Use proper fraction formatting for quantity only
+              displayQuantity = formatIngredientQuantity(parsed.quantity, '') || `${parsed.quantity}`;
             }
           } else {
             displayName = ing;


### PR DESCRIPTION
## Summary
- Fixed issue where fractions like "1/2 cup" were displaying as "/2 cup" or "0.5 cup" in shopping lists
- Now properly displays as "½ cup" using existing formatIngredientQuantity() function

## Changes Made
- **recipe-spoonacular-detail.tsx**: Updated shopping list item creation to use proper fraction formatting
- **recipe-details.tsx**: Applied same fix for locally generated recipes  
- **select-ingredients.tsx**: Fixed same issue in ingredient selection screen

## Technical Details
The bug occurred because ingredient parsing correctly converted fractions to decimals (e.g., "1/2" → 0.5), but when creating shopping list items, the code was bypassing the existing `formatAsFraction()` function and displaying raw decimal values.

## Test Plan
- [x] Add recipe with fractional ingredients to shopping list
- [x] Verify fractions display as proper Unicode symbols (½, ¼, ¾, etc.)
- [x] Test both Spoonacular recipes and local recipes
- [x] Verify ingredient selection screen also displays fractions correctly

## Clean Implementation
This PR is created from a fresh branch off main to avoid the conflicts that were present in the previous PR.